### PR TITLE
Add EOL option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ var eolFix = require('eol-fix-stream');
 
 process.stdin.pipe(eolFix()).pipe(process.stdout);
 ```
+
+By default, all line endings will be `lf` (or `\n` for all you non-nerds). If you would like to use a different line ending, you can specify one:
+
+```javascript
+var eolFix = require('eol-fix-stream');
+
+process.stdin.pipe(eolFix({ eol: '\r\n' })).pipe(process.stdout);
+```
+
+Currently, the only supported line endings are: `\n`, `\r`, and `\r\n`.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = function lfcrClean(eol) {
     // Set a default
     eol = '\n';
   }
-  assert(['\r', '\n', '\r\n'].includes(eol), `Invalid EOL: '${eol}'`);
+
+  assert(['\r', '\n', '\r\n'].includes(eol), 'Invalid EOL: "' + eol + '"');
 
   var crlf = /\r\n|\n\r|\n|\r/g;
   var endCrlf = /\r|\n$/;
@@ -27,7 +28,7 @@ module.exports = function lfcrClean(eol) {
     } else {
       prev = '';
     }
-  
+
     // change any remaining cr or lf to eol
     data = data.replace(crlf, eol);
 

--- a/index.js
+++ b/index.js
@@ -8,14 +8,12 @@ var allowedEol = {
   '\r\n': true
 };
 
-module.exports = function lfcrClean(eol) {
-  if (!eol) {
-    // Set a default
-    eol = '\n';
-  }
+module.exports = function lfcrClean(options) {
+  options = options || {};
+  var eol = options.eol || '\n';
 
   if (!allowedEol[eol]) {
-    throw new Error('Invalid EOL: "' + eol + '"');
+    throw new Error('Invalid `eol` option: "' + eol + '"');
   }
 
   var crlf = /\r\n|\n\r|\n|\r/g;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@
 var through = require('through2');
 var assert = require('assert');
 
-module.exports = function lfcrClean(eol='\n') {
+module.exports = function lfcrClean(eol) {
+  if (!eol) {
+    // Set a default
+    eol = '\n';
+  }
   assert(['\r', '\n', '\r\n'].includes(eol), `Invalid EOL: '${eol}'`);
 
   var crlf = /\r\n|\n\r|\n|\r/g;
@@ -24,7 +28,7 @@ module.exports = function lfcrClean(eol='\n') {
       prev = '';
     }
   
-    // change any remaining cr to eol
+    // change any remaining cr or lf to eol
     data = data.replace(crlf, eol);
 
     cb(null, data);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 /* jshint node: true */
 
 var through = require('through2');
-var assert = require('assert');
+
+var allowedEol = {
+  '\r': true,
+  '\n': true,
+  '\r\n': true
+};
 
 module.exports = function lfcrClean(eol) {
   if (!eol) {
@@ -9,7 +14,9 @@ module.exports = function lfcrClean(eol) {
     eol = '\n';
   }
 
-  assert(['\r', '\n', '\r\n'].includes(eol), 'Invalid EOL: "' + eol + '"');
+  if (!allowedEol[eol]) {
+    throw new Error('Invalid EOL: "' + eol + '"');
+  }
 
   var crlf = /\r\n|\n\r|\n|\r/g;
   var endCrlf = /\r|\n$/;

--- a/index.js
+++ b/index.js
@@ -1,47 +1,36 @@
 /* jshint node: true */
 
 var through = require('through2');
+var assert = require('assert');
 
-module.exports = function lfcrClean() {
-  var endsInLf = false;
-  var endsInCr = false;
+module.exports = function lfcrClean(eol='\n') {
+  assert(['\r', '\n', '\r\n'].includes(eol), `Invalid EOL: '${eol}'`);
 
-  var endLf = /\n$/;
-  var endCr = /\r$/;
-  var startLf = /^\n/;
-  var startCr = /^\r/;
-  var crlf = /\r\n/g;
-  var cr = /\r/g;
-
-  // because Windows CLIs :(
-  var lfcr = /\n\r/g;
+  var crlf = /\r\n|\n\r|\n|\r/g;
+  var endCrlf = /\r|\n$/;
+  var prev = '';
 
   return through(function (chunk, enc, cb) {
     var data = chunk.toString();
 
-    // replace crlf to lf throughout the chunk
-    data = data.replace(crlf, '\n').replace(lfcr, '\n');
-
-    if (endsInLf) {
-      // the previous chunk ended in lf, so if this one starts
-      // in cr, we should just remove the cr (since lf was
-      // already written)
-      data = data.replace(startCr, '');
+    if (prev) {
+      data = prev + data;
     }
 
-    if (endsInCr) {
-      // we would have already replaced that cr with lf,
-      // so just remove the first lf at the start of the
-      // stringfrom this chunk
-      data = data.replace(startLf, '');
+    if (endCrlf.test(data)) {
+      prev = data.slice(-1);
+      data = data.slice(0, -1);
+    } else {
+      prev = '';
     }
-
-    endsInLf = endLf.test(data);
-    endsInCr = endCr.test(data);
-
-    // change any remaining cr to lf
-    data = data.replace(cr, '\n');
+  
+    // change any remaining cr to eol
+    data = data.replace(crlf, eol);
 
     cb(null, data);
+  }, function (cb) {
+    if (prev) {
+      cb(null, prev.replace(crlf, eol));
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
+    "debug": "mocha --inspect-brk",
     "coverage": "istanbul cover --dir coverage node_modules/mocha/bin/_mocha"
   },
   "keywords": ["eol", "fix", "stream", "crlf"],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,6 +33,7 @@ describe('[index]', function () {
   });
 
   it('handles weird lncr business output by Windows CLIs', function (done) {
+    debugger;
     es.readArray([
       'chunk\n', '\rwith\n', '\rline\n', '\rendings'
     ]).pipe(mod()).pipe(es.wait(function (err, data) {
@@ -66,6 +67,19 @@ describe('[index]', function () {
 
       expect(data).to.not.match(/\r\n/g);
       expect(data).to.equal('chunk\nwith\nline\nendings');
+
+      done();
+    }));
+  });
+
+  it('replaces \\n with eol="\\r\\n"', function (done) {
+    es.readArray([
+      'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
+    ]).pipe(mod(eol='\r\n')).pipe(es.wait(function (err, data) {
+      data = data.toString();
+
+//      expect(data).to.not.match(/\r\n/g);
+      expect(data).to.equal('chunk\r\nchunk\r\nchunk\r\nchunk\r\nchunk\r\n');
 
       done();
     }));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -71,15 +71,47 @@ describe('[index]', function () {
     }));
   });
 
-  it('replaces \\n with eol="\\r\\n"', function (done) {
-    es.readArray([
-      'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
-    ]).pipe(mod('\r\n')).pipe(es.wait(function (err, data) {
-      data = data.toString();
+  describe('defining a custom `eol` value', function () {
+    it('accepts \\r\\n as a custom line ending', function (done) {
+      es.readArray([
+        'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
+      ]).pipe(mod('\r\n')).pipe(es.wait(function (err, data) {
+        data = data.toString();
 
-      expect(data).to.equal('chunk\r\nchunk\r\nchunk\r\nchunk\r\nchunk\r\n');
+        expect(data).to.equal('chunk\r\nchunk\r\nchunk\r\nchunk\r\nchunk\r\n');
 
-      done();
-    }));
+        done();
+      }));
+    });
+
+    it('accepts \\r as a custom line ending', function (done) {
+      es.readArray([
+        'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
+      ]).pipe(mod('\r')).pipe(es.wait(function (err, data) {
+        data = data.toString();
+
+        expect(data).to.equal('chunk\rchunk\rchunk\rchunk\rchunk\r');
+
+        done();
+      }));
+    });
+
+    it('accepts \\n as a custom line ending', function (done) {
+      es.readArray([
+        'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
+      ]).pipe(mod('\n')).pipe(es.wait(function (err, data) {
+        data = data.toString();
+
+        expect(data).to.equal('chunk\nchunk\nchunk\nchunk\nchunk\n');
+
+        done();
+      }));
+    });
+
+    it('throws if an unknown custom line ending is used', function () {
+      expect(function () {
+        mod('wat');
+      }).to.throw(Error, 'Invalid EOL: "wat"');
+    });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,7 +75,7 @@ describe('[index]', function () {
     it('accepts \\r\\n as a custom line ending', function (done) {
       es.readArray([
         'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
-      ]).pipe(mod('\r\n')).pipe(es.wait(function (err, data) {
+      ]).pipe(mod({ eol: '\r\n' })).pipe(es.wait(function (err, data) {
         data = data.toString();
 
         expect(data).to.equal('chunk\r\nchunk\r\nchunk\r\nchunk\r\nchunk\r\n');
@@ -87,7 +87,7 @@ describe('[index]', function () {
     it('accepts \\r as a custom line ending', function (done) {
       es.readArray([
         'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
-      ]).pipe(mod('\r')).pipe(es.wait(function (err, data) {
+      ]).pipe(mod({ eol: '\r' })).pipe(es.wait(function (err, data) {
         data = data.toString();
 
         expect(data).to.equal('chunk\rchunk\rchunk\rchunk\rchunk\r');
@@ -99,7 +99,7 @@ describe('[index]', function () {
     it('accepts \\n as a custom line ending', function (done) {
       es.readArray([
         'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
-      ]).pipe(mod('\n')).pipe(es.wait(function (err, data) {
+      ]).pipe(mod({ eol: '\n' })).pipe(es.wait(function (err, data) {
         data = data.toString();
 
         expect(data).to.equal('chunk\nchunk\nchunk\nchunk\nchunk\n');
@@ -110,8 +110,8 @@ describe('[index]', function () {
 
     it('throws if an unknown custom line ending is used', function () {
       expect(function () {
-        mod('wat');
-      }).to.throw(Error, 'Invalid EOL: "wat"');
+        mod({ eol: 'wat' });
+      }).to.throw(Error, 'Invalid `eol` option: "wat"');
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,7 +74,7 @@ describe('[index]', function () {
   it('replaces \\n with eol="\\r\\n"', function (done) {
     es.readArray([
       'chunk\nchunk\rchunk\r\nchunk\r', '\nchunk', '\n',
-    ]).pipe(mod(eol='\r\n')).pipe(es.wait(function (err, data) {
+    ]).pipe(mod('\r\n')).pipe(es.wait(function (err, data) {
       data = data.toString();
 
       expect(data).to.equal('chunk\r\nchunk\r\nchunk\r\nchunk\r\nchunk\r\n');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,7 +33,6 @@ describe('[index]', function () {
   });
 
   it('handles weird lncr business output by Windows CLIs', function (done) {
-    debugger;
     es.readArray([
       'chunk\n', '\rwith\n', '\rline\n', '\rendings'
     ]).pipe(mod()).pipe(es.wait(function (err, data) {
@@ -78,7 +77,6 @@ describe('[index]', function () {
     ]).pipe(mod(eol='\r\n')).pipe(es.wait(function (err, data) {
       data = data.toString();
 
-//      expect(data).to.not.match(/\r\n/g);
       expect(data).to.equal('chunk\r\nchunk\r\nchunk\r\nchunk\r\nchunk\r\n');
 
       done();


### PR DESCRIPTION
 - Caller can now specify desired EOL sequence: `'\r'`, `'\n'` or `'\r\n'`.
 - Simplify implementation.